### PR TITLE
Added cookie_policy wp option in legal-cookies.html

### DIFF
--- a/Countries/Australia/legal-cookies.html
+++ b/Countries/Australia/legal-cookies.html
@@ -2,6 +2,8 @@
 post_title: Cookies Policy
 post_type: page
 post_status: publish
+woocart_defaults:
+  wp/wp_page_for_cookie_policy: $ID
 -->
 
 <p>[company-name] ("us", "we", or "our") uses cookies on the [store-url] website (the "Service"). By using the Service,

--- a/Countries/India/legal-cookies.html
+++ b/Countries/India/legal-cookies.html
@@ -2,6 +2,8 @@
 post_title: Cookies Policy
 post_type: page
 post_status: publish
+woocart_defaults:
+  wp/wp_page_for_cookie_policy: $ID
 -->
 
 <p>[company-name] ("us", "we", or "our") uses cookies on the [store-url] website (the "Service"). By using the Service,

--- a/Countries/Ireland/legal-cookies.html
+++ b/Countries/Ireland/legal-cookies.html
@@ -2,6 +2,8 @@
 post_title: Cookies Policy
 post_type: page
 post_status: publish
+woocart_defaults:
+  wp/wp_page_for_cookie_policy: $ID
 -->
 
 <p>[company-name] ("us", "we", or "our") uses cookies on the [store-url] website (the "Service"). By using the Service,

--- a/Countries/Malta/legal-cookies.html
+++ b/Countries/Malta/legal-cookies.html
@@ -2,6 +2,8 @@
 post_title: Cookies Policy
 post_type: page
 post_status: publish
+woocart_defaults:
+  wp/wp_page_for_cookie_policy: $ID
 -->
 
 <p>[company-name] ("us", "we", or "our") uses cookies on the [store-url] website (the "Service"). By using the Service,

--- a/Countries/Nigeria/legal-cookies.html
+++ b/Countries/Nigeria/legal-cookies.html
@@ -2,6 +2,8 @@
 post_title: Cookies Policy
 post_type: page
 post_status: publish
+woocart_defaults:
+  wp/wp_page_for_cookie_policy: $ID
 -->
 
 <p>[company-name] ("us", "we", or "our") uses cookies on the [store-url] website (the "Service"). By using the Service,

--- a/Countries/Pakistan/legal-cookies.html
+++ b/Countries/Pakistan/legal-cookies.html
@@ -2,6 +2,8 @@
 post_title: Cookies Policy
 post_type: page
 post_status: publish
+woocart_defaults:
+  wp/wp_page_for_cookie_policy: $ID
 -->
 
 <p>[company-name] ("us", "we", or "our") uses cookies on the [store-url] website (the "Service"). By using the Service,

--- a/Countries/Philippines/legal-cookies.html
+++ b/Countries/Philippines/legal-cookies.html
@@ -2,6 +2,8 @@
 post_title: Cookies Policy
 post_type: page
 post_status: publish
+woocart_defaults:
+  wp/wp_page_for_cookie_policy: $ID
 -->
 
 <p>[company-name] ("us", "we", or "our") uses cookies on the [store-url] website (the "Service"). By using the Service,

--- a/Countries/Romania/legal-cookies.html
+++ b/Countries/Romania/legal-cookies.html
@@ -2,6 +2,8 @@
 post_title: Informații despre cookie-uri
 post_type: page
 post_status: publish
+woocart_defaults:
+  wp/wp_page_for_cookie_policy: $ID
 -->
 
 Aceste informații se referă la cookie-urile și la tehnologiile similare folosite, după caz, în website-ul [store-url]

--- a/Countries/Singapore/legal-cookies.html
+++ b/Countries/Singapore/legal-cookies.html
@@ -2,6 +2,8 @@
 post_title: Cookies Policy
 post_type: page
 post_status: publish
+woocart_defaults:
+  wp/wp_page_for_cookie_policy: $ID
 -->
 
 <p>[company-name] ("us", "we", or "our") uses cookies on the [store-url] website (the "Service"). By using the Service,

--- a/Countries/South Africa/legal-cookies.html
+++ b/Countries/South Africa/legal-cookies.html
@@ -2,6 +2,8 @@
 post_title: Cookies Policy
 post_type: page
 post_status: publish
+woocart_defaults:
+  wp/wp_page_for_cookie_policy: $ID
 -->
 
 <p>[company-name] ("us", "we", or "our") uses cookies on the [store-url] website (the "Service"). By using the Service,

--- a/Countries/United Kingdom/legal-cookies.html
+++ b/Countries/United Kingdom/legal-cookies.html
@@ -2,6 +2,8 @@
 post_title: Cookie Policy
 post_type: page
 post_status: publish
+woocart_defaults:
+  wp/wp_page_for_cookie_policy: $ID
 -->
 
 <p>[company-name] ("us", "we", or "our") uses cookies on the [store-url] website (the "Service"). By using the Service,


### PR DESCRIPTION
Setting the `wp_page_cookie_policy` in the `legal-cookies.html` page.