### PR TITLE
Change UK code to GB code for tax purposes

### DIFF
--- a/Countries/United Kingdom/local.yaml
+++ b/Countries/United Kingdom/local.yaml
@@ -21,7 +21,7 @@ woo/woocommerce_tax_classes:
    - Reduced
    - Zero # If more than one reduced rate add '\nReduced rate 2'
 wootax/1: # Standard rate
-    country: UK
+    country: GB
     state: ''
     rate: '20.0000'
     name: VAT # Translate
@@ -32,7 +32,7 @@ wootax/1: # Standard rate
     class: ''
     locations: {  }
 wootax/2: # Reduced rate
-    country: UK
+    country: GB
     state: ''
     rate: '5.0000'
     name: VAT # Translate
@@ -43,7 +43,7 @@ wootax/2: # Reduced rate
     class: 'reduced'
     locations: {  }
 wootax/3: # Zero rate
-    country: UK
+    country: GB
     state: ''
     rate: '0.0000'
     name: VAT # Translate


### PR DESCRIPTION
For Tax calculations, WooCommerce takes into consideration `GB` as the country code and not `UK`. 

So, we are changing it in the `local.yaml` to `GB` and testing things out to look for any further issues.

Ref: https://github.com/niteoweb/woocart/issues/453