### PR TITLE
Change tax calculation to shop base address

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -82,7 +82,7 @@ woo/woocommerce_anonymize_completed_orders: # Retain completed orders
 
 # Tax
 woo/woocommerce_prices_include_tax: 'yes' # Prices entered with tax
-woo/woocommerce_tax_based_on: 'billing' # Tax based on shipping or billing address
+woo/woocommerce_tax_based_on: 'base' # Tax based on shop base address (other options are shipping and billing)
 woo/woocommerce_tax_round_at_subtotal: 'no' # Round tax at subtotal level, instead of rounding per line
 woo/woocommerce_tax_classes: # Additional rates
   - Reduced


### PR DESCRIPTION
We are making tax calculation to be based off on `shop base address` by default.