### PR TITLE
Searched for line breaks in <p> and <li> lines in localization files.

### DIFF
--- a/Countries/.common/legal-privacy-policy.html
+++ b/Countries/.common/legal-privacy-policy.html
@@ -255,3 +255,4 @@ woocart_defaults:
 
   <h2>Contact Us</h2>
   <p>If you have any questions about this Privacy Policy, please contact us.</p>
+</p>


### PR DESCRIPTION
Search code (same works for li):
$ fgrep -Hnr "<p" Countries  | fgrep ".html" | fgrep -v "</p"

There were only a couple instances for each of the tags.  Hand reviewed all
of them, there were no issues, but I did find an unclosed <p> in
.common/legal-privacy-policy.html. Fixed.

Ref: #61