### PR TITLE
Add shortcodes to legal pages

### DIFF
--- a/Countries/.common/legal-cookies.html
+++ b/Countries/.common/legal-cookies.html
@@ -60,3 +60,6 @@ woocart_defaults:
 <h3>Where can you find more information about cookies</h3>
 
 <p>You can learn more about cookies on <a href="http://www.allaboutcookies.org/" target="_blank">AllAboutCookies</a> and <a href="http://www.networkadvertising.org/" target="_blank">Network Advertising Initiative</a>.</p>
+
+<h3>Contact Us</h3>
+<p>If you have any questions about this Cookie Policy, please [contact-page]<a href="%s">contact us</a>[/contact-page].</p>

--- a/Countries/.common/legal-privacy-policy.html
+++ b/Countries/.common/legal-privacy-policy.html
@@ -16,7 +16,7 @@ woocart_defaults:
 
 <p>We use your data to provide and improve the Service. By using the Service, you agree to the collection and use of information in accordance with this policy.</p>
 
-<p>Unless otherwise defined in this Privacy Policy, terms used in this Privacy Policy have the same meanings as in our Terms and Conditions, accessible from [store-url].</p>
+<p>Unless otherwise defined in this Privacy Policy, terms used in this Privacy Policy have the same meanings as in our [terms-page]<a href="%s">Terms and Conditions</a>[/terms-page], accessible from [store-url].</p>
 
 <h3>Definitions</h3>
 
@@ -55,7 +55,7 @@ woocart_defaults:
   <li>Address, Postcode, City</li>
   <li>Cookies and Usage Data</li>
 </ul>
-<p>We may use your Personal Data to contact you with newsletters, marketing or promotional materials and other information that may be of interest to you. You may opt out of receiving any, or all, of these communications from us by following the unsubscribe link or instructions provided in any email we send or by contacting us.</p>
+<p>We may use your Personal Data to contact you with newsletters, marketing or promotional materials and other information that may be of interest to you. You may opt out of receiving any, or all, of these communications from us by following the unsubscribe link or instructions provided in any email we send or by [contact-page]<a href="%s">contacting us</a>[/contact-page].</p>
 
 <strong>Usage Data</strong>
 
@@ -158,11 +158,11 @@ woocart_defaults:
 
   <p>If you are a resident of the European Economic Area (EEA), you have certain data protection rights. [company-name] aims to take reasonable steps to allow you to correct, amend, delete, or limit the use of your Personal Data.</p>
 
-  <p>If you wish to be informed what Personal Data we hold about you and if you want it to be removed from our systems, please contact us.</p>
+  <p>If you wish to be informed what Personal Data we hold about you and if you want it to be removed from our systems, please [contact-page]<a href="%s">contact us</a>[/contact-page].</p>
 
   <p>In certain circumstances, you have the following data protection rights:</p>
   <ul>
-    <li>The right to access, update or to delete the information we have on you. Whenever made possible, you can access, update or request deletion of your Personal Data directly within your account settings section. If you are unable to perform these actions yourself, please contact us to assist you.</li>
+    <li>The right to access, update or to delete the information we have on you. Whenever made possible, you can access, update or request deletion of your Personal Data directly within your account settings section. If you are unable to perform these actions yourself, please [contact-page]<a href="%s">contact us</a>[/contact-page] to assist you.</li>
     <li>The right of rectification. You have the right to have your information rectified if that information is inaccurate or incomplete.</li>
     <li>The right to object. You have the right to object to our processing of your Personal Data.</li>
     <li>The right of restriction. You have the right to request that we restrict the processing of your personal information.</li>
@@ -253,7 +253,7 @@ woocart_defaults:
   <h3>Children's Privacy</h3>
   <p>Our Service does not address anyone under the age of 18 ("Children").</p>
 
-  <p>We do not knowingly collect personally identifiable information from anyone under the age of 18. If you are a parent or guardian and you are aware that your child has provided us with Personal Data, please contact us. If we become aware that we have collected Personal Data from children without verification of parental consent, we take steps to remove that information from our servers.</p>
+  <p>We do not knowingly collect personally identifiable information from anyone under the age of 18. If you are a parent or guardian and you are aware that your child has provided us with Personal Data, please [contact-page]<a href="%s">contact us</a>[/contact-page]. If we become aware that we have collected Personal Data from children without verification of parental consent, we take steps to remove that information from our servers.</p>
 
   <h3>Changes to This Privacy Policy</h3>
   <p>We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page.</p>
@@ -263,5 +263,5 @@ woocart_defaults:
   <p>You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.</p>
 
   <h3>Contact Us</h3>
-  <p>If you have any questions about this Privacy Policy, please contact us.</p>
+  <p>If you have any questions about this Privacy Policy, please [contact-page]<a href="%s">contact us</a>[/contact-page].</p>
 </p>

--- a/Countries/.common/legal-privacy-policy.html
+++ b/Countries/.common/legal-privacy-policy.html
@@ -264,4 +264,3 @@ woocart_defaults:
 
   <h3>Contact Us</h3>
   <p>If you have any questions about this Privacy Policy, please [contact-page]<a href="%s">contact us</a>[/contact-page].</p>
-</p>

--- a/Countries/.common/legal-returns-and-refunds.html
+++ b/Countries/.common/legal-returns-and-refunds.html
@@ -24,7 +24,7 @@ woocart_defaults:
 
 <p>Products that do not meet these criteria will not be considered for return.</p>
 
-<p>Please contact us before you send the product.</p>
+<p>Please [contact-page]<a href="%s">contact us</a>[/contact-page] before you send the product.</p>
 
 <h3>Shipping charges</h3>
 <p>Shipping charges incurred in connection with the return of a product are non-refundable.</p>
@@ -43,4 +43,4 @@ woocart_defaults:
 <p>We recommend contacting us for assistance if you experience any issues receiving or downloading our products.</p>
 
 <h3>Contact us</h3>
-<p>If you have any questions about our Returns and Refunds Policy, please contact us.</p>
+<p>If you have any questions about our Returns and Refunds Policy, please [contact-page]<a href="%s">contact us</a>[/contact-page].</p>

--- a/Countries/.common/legal-terms-and-conditions.html
+++ b/Countries/.common/legal-terms-and-conditions.html
@@ -33,7 +33,7 @@ woocart_defaults:
 <p>We cannot and do not guarantee the accuracy or completeness of any information, including prices, product images, specifications, availability, and services. We reserve the right to change or update information and to correct errors, inaccuracies, or omissions at any time without prior notice. Section "Availability, Errors and Inaccuracies" is without prejudice to existing statutory rights.</p>
 
 <h3>Contests, Sweepstakes, and Promotions</h3>
-<p>Any contests, sweepstakes or other promotions (collectively, "Promotions") made available through the Service may be governed by rules that are separate from these Terms. If you participate in any Promotions, please review the applicable rules as well as our Privacy Policy. If the rules for a Promotion conflict with these Terms and Conditions, the Promotion rules will apply. The terms and conditions of any other "Promotions" are independent of this agreement.</p>
+<p>Any contests, sweepstakes or other promotions (collectively, "Promotions") made available through the Service may be governed by rules that are separate from these Terms. If you participate in any Promotions, please review the applicable rules as well as our [policy-page]<a href="%s">Privacy Policy</a>[/policy-page]. If the rules for a Promotion conflict with these Terms and Conditions, the Promotion rules will apply. The terms and conditions of any other "Promotions" are independent of this agreement.</p>
 
 <h3>Accounts</h3>
 <p>When you create an account with us, you must provide us with information that is accurate, complete, and current at all times. Failure to do so constitutes a breach of the Terms, which may result in immediate termination of your account on our Service.</p>
@@ -83,7 +83,7 @@ woocart_defaults:
 <p>By continuing to access or use our Service after those revisions become effective, you agree to be bound by the revised terms. If you do not agree to the new terms, you must stop using the service.</p>
 
 <h3>Privacy Policy and Cookie Policy</h3>
-<p>Please refer to our Privacy Policy and Cookies Policy. You agree that they constitute part of these terms. You must read our Privacy Policy and Cookies Policy before you use the Service.</p>
+<p>Please refer to our [policy-page]<a href="%s">Privacy Policy</a>[/policy-page] and [cookie-page]<a href="%s">Cookies Policy</a>[/cookie-page]. You agree that they constitute part of these terms. You must read our [policy-page]<a href="%s">Privacy Policy</a>[/policy-page] and [cookie-page]<a href="%s">Cookies Policy</a>[/cookie-page] before you use the Service.</p>
 
 <h3>Contact Us</h3>
-<p>If you have any questions about these Terms, please contact us.</p>
+<p>If you have any questions about these Terms, please [contact-page]<a href="%s">contact us</a>[/contact-page].</p>


### PR DESCRIPTION
Refs: https://github.com/niteoweb/woocart/issues/781

This PR adds shortcodes to:

- Privacy Policy
- Terms and Conditions
- Returns and Refunds
- Cookies Policy
