### PR TITLE
Add store page for woocommerce

### DIFF
--- a/Countries/.common/store.html
+++ b/Countries/.common/store.html
@@ -1,0 +1,8 @@
+<!--
+post_title: Store
+post_name: store
+post_type: page
+post_status: publish
+woocart_defaults:
+  wp/woocommerce_shop_page_id: $ID
+-->


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart-app/issues/833

Add shop page with name and slug - `store` so that it works with the hardcoded links in the templates for the demo content.