### PR TITLE
Replace links with woo-permalink shortcode

### DIFF
--- a/Countries/.common/home.html
+++ b/Countries/.common/home.html
@@ -31,8 +31,8 @@ woocart_defaults:
     <!-- wp:cover {"url":"/wp-content/uploads/demo-content/home-2.jpg","id":1036} -->
     <div class="wp-block-cover has-background-dim"
       style="background-image:url(/wp-content/uploads/demo-content/home-2.jpg)">
-      <p class="wp-block-cover-text"><strong><a href="/store">20% OFF ON
-            ACCESSORIES</a><br></strong></p>
+      <p class="wp-block-cover-text"><strong>[woo-permalink option="woocommerce_shop_page_id"]<a href="%s">20% OFF ON </a>[/woo-permalink]</strong><br>
+        <strong>[woo-permalink option="woocommerce_shop_page_id"]<a href="%s">ACCESSORIES</a>[/woo-permalink]</strong></p>
     </div>
     <!-- /wp:cover -->
   </div>
@@ -43,9 +43,8 @@ woocart_defaults:
     <!-- wp:cover {"url":"/wp-content/uploads/demo-content/home-3.jpg","id":1044} -->
     <div class="wp-block-cover has-background-dim"
       style="background-image:url(/wp-content/uploads/demo-content/home-3.jpg)">
-      <p class="wp-block-cover-text"><strong><a href="/store">LATEST </a></strong><a
-          href="/store"><br></a><strong><a
-            href="/store">EYEWEAR</a></strong></p>
+      <p class="wp-block-cover-text"><strong>[woo-permalink option="woocommerce_shop_page_id"]<a href="%s">LATEST </a>[/woo-permalink]</strong><br>
+        <strong>[woo-permalink option="woocommerce_shop_page_id"]<a href="%s">EYEWEAR</a>[/woo-permalink]</strong></p>
     </div>
     <!-- /wp:cover -->
   </div>
@@ -56,7 +55,8 @@ woocart_defaults:
     <!-- wp:cover {"url":"/wp-content/uploads/demo-content/home-4.jpg","id":1037} -->
     <div class="wp-block-cover has-background-dim"
       style="background-image:url(/wp-content/uploads/demo-content/home-4.jpg)">
-      <p class="wp-block-cover-text"><strong><a href="/store">LET'S LOREM</a></strong><a href="/store"><br></a><strong><a href="/store">SUIT UP!</a></strong></p>
+      <p class="wp-block-cover-text"><strong>[woo-permalink option="woocommerce_shop_page_id"]<a href="%s">LET'S LOREM </a>[/woo-permalink]</strong><br>
+        <strong>[woo-permalink option="woocommerce_shop_page_id"]<a href="%s">SUIT UP!</a>[/woo-permalink]</strong></p>
     </div>
     <!-- /wp:cover -->
   </div>


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart-app/issues/833

Replace hardcoded links with the `woo-permalink` shortcode. Works as expected in the Docker version.
<img width="1227" alt="Screenshot 2019-06-07 at 6 00 07 PM" src="https://user-images.githubusercontent.com/266324/59104163-6e26c600-894e-11e9-9812-01aed901ae66.png">
