### PR TITLE
Fix cookies page

### DIFF
--- a/Countries/.common/legal-cookies.html
+++ b/Countries/.common/legal-cookies.html
@@ -53,7 +53,7 @@ woocart_defaults:
   <li>For the Chrome web browser, please visit <a href="https://support.google.com/accounts/answer/32050" target="_blank">this page from Google</a>.</li>
   <li>For the Internet Explorer web browser, please visit <a href="http://support.microsoft.com/kb/278835" target="_blank">this page from Microsoft</a>.</li>
   <li>For the Firefox web browser, please visit this page from <a href="https://support.mozilla.org/en-US/kb/delete-cookies-remove-info-websites-stored" target="_blank">this page from Mozilla</a>.</li>
-  <li>For the Safari web browser, please visit <a href="https://support.apple.</li>com/kb/PH21411?locale=en_US" target="_blank">this page from Apple</a>.</li>
+  <li>For the Safari web browser, please visit <a href="https://support.apple.com/kb/PH21411?locale=en_US" target="_blank">this page from Apple</a>.</li>
   <li>For any other web browser, please visit your web browser's official web pages.</li>
 </ul>
 


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart-app/issues/875

Fixes misaligned and missing text on the cookies page due to the presence of `</li>` within the anchor tag.