### PR TITLE
Add metadata to local.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .venv/
 .installed
 .mypy_cache/

--- a/Countries/Japan/local.yaml
+++ b/Countries/Japan/local.yaml
@@ -71,4 +71,5 @@ woo/woocommerce_registration_privacy_policy_text: 'Your personal data will be us
 # Metadata -- KEEP --
 .woo/woocommerce_bacs_settings_format: serialized
 .woo/woocommerce_cod_settings_format: serialized
+.woo/woocommerce_tax_classes_format: implode_newline
 # Metadata -- KEEP --


### PR DESCRIPTION
Added a missing line to the `Metadata` section. 

Ref: https://github.com/niteoweb/woocart/issues/1083