### PR TITLE
Default to fully translated languages

### DIFF
--- a/Countries/Belgium/local.yaml
+++ b/Countries/Belgium/local.yaml
@@ -5,7 +5,7 @@ wp/time_format: 'H:i' # "H:i" for 24-hour clock, "g:i A" for 12-hour clock
 wp/start_of_week: '1' # 1= Monday, 7=Sunday
 wp/timezone_string: 'Europe/Brussels' # Timezone string https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 wp/blog_charset: 'UTF-8'
-wp/DEFAULT_WPLANG: 'nl_BE' # http://api.wordpress.org/translations/core/1.0/
+wp/DEFAULT_WPLANG: 'nl_NL' # http://api.wordpress.org/translations/core/1.0/
 woo/woocommerce_weight_unit: 'kg' # Measurements weight unit kg, g, lbs, oz
 woo/woocommerce_dimension_unit: 'cm' # Measurements dimension unit m, cm, mm, in, yd
 # Currency options

--- a/Countries/Chile/local.yaml
+++ b/Countries/Chile/local.yaml
@@ -5,7 +5,7 @@ wp/time_format: 'H:i' # "H:i" for 24-hour clock, "g:i A" for 12-hour clock
 wp/start_of_week: '1' # 1= Monday, 7=Sunday
 wp/timezone_string: 'America/Santiago' # Timezone string https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 wp/blog_charset: 'UTF-8'
-wp/DEFAULT_WPLANG: 'es_CL' # http://api.wordpress.org/translations/core/1.0/
+wp/DEFAULT_WPLANG: 'es_ES' # http://api.wordpress.org/translations/core/1.0/
 woo/woocommerce_weight_unit: 'kg' # Measurements weight unit kg, g, lbs, oz
 woo/woocommerce_dimension_unit: 'cm' # Measurements dimension unit m, cm, mm, in, yd
 # Currency options

--- a/Countries/Peru/local.yaml
+++ b/Countries/Peru/local.yaml
@@ -5,7 +5,7 @@ wp/time_format: 'g:i A' # "H:i" for 24-hour clock, "g:i A" for 12-hour clock
 wp/start_of_week: '1' # 1= Monday, 7=Sunday
 wp/timezone_string: 'America/Lima' # Timezone string https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 wp/blog_charset: 'UTF-8'
-wp/DEFAULT_WPLANG: 'es_PE' # http://api.wordpress.org/translations/core/1.0/
+wp/DEFAULT_WPLANG: 'es_ES' # http://api.wordpress.org/translations/core/1.0/
 woo/woocommerce_weight_unit: 'kg' # Measurements weight unit kg, g, lbs, oz
 woo/woocommerce_dimension_unit: 'cm' # Measurements dimension unit m, cm, mm, in, yd
 # Currency options


### PR DESCRIPTION
If local language is translated less than 80%, revert to the main language.
See https://translate.wordpress.org/projects/wp-plugins/woocommerce/

Ref: https://github.com/niteoweb/woocart/issues/1528