### PR TITLE
Update default languages

### DIFF
--- a/Countries/Luxembourg/local.yaml
+++ b/Countries/Luxembourg/local.yaml
@@ -5,7 +5,7 @@ wp/time_format: 'H:i' # "H:i" for 24-hour clock, "g:i A" for 12-hour clock
 wp/start_of_week: '1' # 1= Monday, 7=Sunday
 wp/timezone_string: 'Europe/Luxembourg' # Timezone string https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 wp/blog_charset: 'UTF-8'
-wp/DEFAULT_WPLANG: 'fr_BE' # http://api.wordpress.org/translations/core/1.0/
+wp/DEFAULT_WPLANG: 'fr_FR' # http://api.wordpress.org/translations/core/1.0/
 woo/woocommerce_weight_unit: 'kg' # Measurements weight unit kg, g, lbs, oz
 woo/woocommerce_dimension_unit: 'cm' # Measurements dimension unit m, cm, mm, in, yd
 # Currency options


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/1528

We will be removing few languages from the app wizard. So, this PR changes the default languages for the affected countries.

Seems like, only entry for Luxembourg needs to be changed. Once this PR is merged, `make codegen` needs to be run on the other open PR for `woocart-app`