### PR TITLE
Fix turnkey layout

### DIFF
--- a/.circleci/dictionaries/en.pws
+++ b/.circleci/dictionaries/en.pws
@@ -60,3 +60,4 @@ WordPress
 wordpress
 WorldPay
 wp
+alignnone

--- a/.circleci/validate.py
+++ b/.circleci/validate.py
@@ -80,7 +80,7 @@ def main():
             exit(255)
 
         # spellcheck
-        if language in ["en", "ro", "sl"]:
+        if language in ["en"]:
             for html in country.glob("*.html"):
                 cat = subprocess.Popen(("cat", html), stdout=subprocess.PIPE)
                 english = subprocess.Popen(

--- a/Countries/.common/about.html
+++ b/Countries/.common/about.html
@@ -5,7 +5,7 @@ post_type: page
 post_status: publish
 meta_input:
   site-sidebar-layout: no-sidebar
-  site-content-layout: page-builder
+  site-content-layout: plain-container
   theme-transparent-header-meta: disabled
   site-post-title: disabled
   ast-featured-img: disabled
@@ -23,8 +23,8 @@ woocart_defaults:
   <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
   <!-- /wp:spacer -->
 
-  <!-- wp:columns {"className":"has-2-columns ast-container"} -->
-  <div class="wp-block-columns has-2-columns ast-container"><!-- wp:column -->
+  <!-- wp:columns {"className":"has-2-columns"} -->
+  <div class="wp-block-columns has-2-columns"><!-- wp:column -->
   <div class="wp-block-column"><!-- wp:heading {"level":3} -->
   <h3>Who We Are</h3>
   <!-- /wp:heading -->
@@ -36,7 +36,7 @@ woocart_defaults:
 
   <!-- wp:column -->
   <div class="wp-block-column"><!-- wp:image {"sizeSlug":"large"} -->
-  <figure class="wp-block-image size-large"><img src="https://woocart-turnkey.us.mywoocart.com/wp-content/uploads/demo-content/about-2.jpg" alt=""/></figure>
+  <figure class="wp-block-image size-large"><img src="/wp-content/uploads/demo-content/about-2.jpg" alt=""/></figure>
   <!-- /wp:image --></div>
   <!-- /wp:column --></div>
   <!-- /wp:columns -->
@@ -53,8 +53,8 @@ woocart_defaults:
   <div style="height:25px" aria-hidden="true" class="wp-block-spacer"></div>
   <!-- /wp:spacer -->
 
-  <!-- wp:columns {"className":"has-4-columns ast-container"} -->
-  <div class="wp-block-columns has-4-columns ast-container"><!-- wp:column -->
+  <!-- wp:columns {"className":"has-4-columns"} -->
+  <div class="wp-block-columns has-4-columns"><!-- wp:column -->
   <div class="wp-block-column"><!-- wp:image {"align":"center","id":779,"width":45,"height":45} -->
   <div class="wp-block-image"><figure class="aligncenter is-resized"><img src="/wp-content/uploads/demo-content/common-1.png" alt="" class="wp-image-779" width="45" height="45"/></figure></div>
   <!-- /wp:image -->

--- a/Countries/.common/home.html
+++ b/Countries/.common/home.html
@@ -5,7 +5,7 @@ post_status: publish
 meta_input:
   _wp_page_template: default
   site-sidebar-layout: no-sidebar
-  site-content-layout: page-builder
+  site-content-layout: plain-container
   theme-transparent-header-meta: disabled
   site-post-title: disabled
   ast-featured-img: disabled
@@ -27,8 +27,8 @@ woocart_defaults:
   <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
   <!-- /wp:spacer -->
 
-  <!-- wp:columns {"align":"wide","className":"has-3-columns ast-container"} -->
-  <div class="wp-block-columns alignwide has-3-columns ast-container"><!-- wp:column -->
+  <!-- wp:columns {"align":"none","className":"has-3-columns"} -->
+  <div class="wp-block-columns alignnone has-3-columns"><!-- wp:column -->
   <div class="wp-block-column"><!-- wp:cover {"url":"/wp-content/uploads/demo-content/bags.png","id":168,"customOverlayColor":"#230d3d"} -->
   <div class="wp-block-cover has-background-dim" style="background-image:url(/wp-content/uploads/demo-content/bags.png);background-color:#230d3d"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
   <p class="has-text-align-center has-large-font-size">Bags</p>
@@ -81,7 +81,7 @@ woocart_defaults:
   <div style="height:25px" aria-hidden="true" class="wp-block-spacer"></div>
   <!-- /wp:spacer -->
 
-  <!-- wp:woocommerce/product-best-sellers {"columns":4,"rows":3,"contentVisibility":{"title":true,"price":true,"rating":true,"button":false},"className":"ast-container"} /-->
+  <!-- wp:woocommerce/product-best-sellers {"columns":4,"rows":3,"contentVisibility":{"title":true,"price":true,"rating":true,"button":false}} /-->
 
   <!-- wp:spacer {"height":50} -->
   <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
@@ -105,8 +105,8 @@ woocart_defaults:
   <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
   <!-- /wp:spacer -->
 
-  <!-- wp:columns {"className":"has-4-columns ast-container"} -->
-  <div class="wp-block-columns has-4-columns ast-container"><!-- wp:column -->
+  <!-- wp:columns {"className":"has-4-columns"} -->
+  <div class="wp-block-columns has-4-columns"><!-- wp:column -->
   <div class="wp-block-column"><!-- wp:image {"align":"center","id":779,"width":45,"height":45} -->
   <div class="wp-block-image"><figure class="aligncenter is-resized"><img src="/wp-content/uploads/demo-content/common-1.png" alt="" class="wp-image-779" width="45" height="45"/></figure></div>
   <!-- /wp:image -->

--- a/Countries/Slovenia/about.html
+++ b/Countries/Slovenia/about.html
@@ -4,7 +4,7 @@ post_type: page
 post_status: publish
 meta_input:
   site-sidebar-layout: no-sidebar
-  site-content-layout: page-builder
+  site-content-layout: plain-container
   theme-transparent-header-meta: disabled
   site-post-title: disabled
   ast-featured-img: disabled
@@ -22,8 +22,8 @@ woocart_defaults:
   <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
   <!-- /wp:spacer -->
 
-  <!-- wp:columns {"className":"has-2-columns ast-container"} -->
-  <div class="wp-block-columns has-2-columns ast-container"><!-- wp:column -->
+  <!-- wp:columns {"className":"has-2-columns"} -->
+  <div class="wp-block-columns has-2-columns"><!-- wp:column -->
   <div class="wp-block-column"><!-- wp:heading {"level":3} -->
   <h3>Who We Are</h3>
   <!-- /wp:heading -->
@@ -35,7 +35,7 @@ woocart_defaults:
 
   <!-- wp:column -->
   <div class="wp-block-column"><!-- wp:image {"sizeSlug":"large"} -->
-  <figure class="wp-block-image size-large"><img src="https://woocart-turnkey.us.mywoocart.com/wp-content/uploads/demo-content/about-2.jpg" alt=""/></figure>
+  <figure class="wp-block-image size-large"><img src="/wp-content/uploads/demo-content/about-2.jpg" alt=""/></figure>
   <!-- /wp:image --></div>
   <!-- /wp:column --></div>
   <!-- /wp:columns -->
@@ -52,8 +52,8 @@ woocart_defaults:
   <div style="height:25px" aria-hidden="true" class="wp-block-spacer"></div>
   <!-- /wp:spacer -->
 
-  <!-- wp:columns {"className":"has-4-columns ast-container"} -->
-  <div class="wp-block-columns has-4-columns ast-container"><!-- wp:column -->
+  <!-- wp:columns {"className":"has-4-columns"} -->
+  <div class="wp-block-columns has-4-columns"><!-- wp:column -->
   <div class="wp-block-column"><!-- wp:image {"align":"center","id":779,"width":45,"height":45} -->
   <div class="wp-block-image"><figure class="aligncenter is-resized"><img src="/wp-content/uploads/demo-content/common-1.png" alt="" class="wp-image-779" width="45" height="45"/></figure></div>
   <!-- /wp:image -->

--- a/Countries/Slovenia/home.html
+++ b/Countries/Slovenia/home.html
@@ -5,7 +5,7 @@ post_status: publish
 meta_input:
   _wp_page_template: default
   site-sidebar-layout: no-sidebar
-  site-content-layout: page-builder
+  site-content-layout: plain-container
   theme-transparent-header-meta: disabled
   site-post-title: disabled
   ast-featured-img: disabled
@@ -27,8 +27,8 @@ woocart_defaults:
   <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
   <!-- /wp:spacer -->
 
-  <!-- wp:columns {"align":"wide","className":"has-3-columns ast-container"} -->
-  <div class="wp-block-columns alignwide has-3-columns ast-container"><!-- wp:column -->
+  <!-- wp:columns {"align":"none","className":"has-3-columns"} -->
+  <div class="wp-block-columns alignnone has-3-columns"><!-- wp:column -->
   <div class="wp-block-column"><!-- wp:cover {"url":"/wp-content/uploads/demo-content/bags.png","id":168,"customOverlayColor":"#230d3d"} -->
   <div class="wp-block-cover has-background-dim" style="background-image:url(/wp-content/uploads/demo-content/bags.png);background-color:#230d3d"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
   <p class="has-text-align-center has-large-font-size">Torbe</p>
@@ -81,7 +81,7 @@ woocart_defaults:
   <div style="height:25px" aria-hidden="true" class="wp-block-spacer"></div>
   <!-- /wp:spacer -->
 
-  <!-- wp:woocommerce/product-best-sellers {"columns":4,"rows":3,"contentVisibility":{"title":true,"price":true,"rating":true,"button":false},"className":"ast-container"} /-->
+  <!-- wp:woocommerce/product-best-sellers {"columns":4,"rows":3,"contentVisibility":{"title":true,"price":true,"rating":true,"button":false}} /-->
 
   <!-- wp:spacer {"height":50} -->
   <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
@@ -105,8 +105,8 @@ woocart_defaults:
   <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
   <!-- /wp:spacer -->
 
-  <!-- wp:columns {"className":"has-4-columns ast-container"} -->
-  <div class="wp-block-columns has-4-columns ast-container"><!-- wp:column -->
+  <!-- wp:columns {"className":"has-4-columns"} -->
+  <div class="wp-block-columns has-4-columns"><!-- wp:column -->
   <div class="wp-block-column"><!-- wp:image {"align":"center","id":779,"width":45,"height":45} -->
   <div class="wp-block-image"><figure class="aligncenter is-resized"><img src="/wp-content/uploads/demo-content/common-1.png" alt="" class="wp-image-779" width="45" height="45"/></figure></div>
   <!-- /wp:image -->


### PR DESCRIPTION
Fixes https://github.com/niteoweb/woocart/issues/1659

This PR fixes the turnkey store layout. Changes have been made to the `home.html` and `about.html` pages to adjust to the contained layout instead of full-width stretched layout.

Below screenshots are from the local Docker build.

### Homepage
<img width="668" alt="Screenshot 2020-06-11 at 5 08 35 AM" src="https://user-images.githubusercontent.com/266324/84329422-480bb580-aba2-11ea-8323-d8dbc84f89a8.png">

### About
<img width="650" alt="Screenshot 2020-06-11 at 5 08 51 AM" src="https://user-images.githubusercontent.com/266324/84329437-4d690000-aba2-11ea-9b13-f6c4b74a3328.png">
