### PR TITLE
Add manual trigger for poetry update

### DIFF
--- a/.github/workflows/poetry-update.yml
+++ b/.github/workflows/poetry-update.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     # On the second of every month
     - cron: '0 0 2 * *'
+  workflow_dispatch:
+    # Manually trigger from the "Actions" tab
 
 jobs:
   update:


### PR DESCRIPTION
With this, we can go to the "Actions" tab and run the workflow for
updating Python packages anytime.