### PR TITLE
Run `poetry update` instead of `poetry lock`

### DIFF
--- a/.github/workflows/poetry-update.sh
+++ b/.github/workflows/poetry-update.sh
@@ -4,7 +4,7 @@ set -xeu
 git fetch --unshallow
 
 # Update the python packages
-poetry update
+poetry lock
 
 # Only continue if there are any changes
 if ! git diff-index --quiet HEAD; then


### PR DESCRIPTION
As per https://python-poetry.org/docs/cli `poetry lock` updates
`poetry.lock` without needing to install the dependencies.